### PR TITLE
Fix: Change default log level from INFO to WARNING

### DIFF
--- a/binarysniffer/core/config.py
+++ b/binarysniffer/core/config.py
@@ -56,7 +56,7 @@ class Config:
     update_check_interval_days: int = 7
     
     # Logging
-    log_level: str = "INFO"
+    log_level: str = "WARNING"
     log_file: Optional[str] = None
     
     def __post_init__(self):


### PR DESCRIPTION
## Summary
- Changed default log level from INFO to WARNING in `binarysniffer/core/config.py`
- This prevents INFO-level messages from cluttering normal output
- Users can still enable verbose output with `-v` (INFO) or `-vv` (DEBUG) flags

## Problem
Issue #33 reported that INFO and WARNING logs were appearing in normal output without the verbose flag enabled, making it difficult to read actual analysis results. Messages like "Loaded X license signatures" and "Extracted N features" were polluting the output during regular use.

## Solution
Changed the default `log_level` from `"INFO"` to `"WARNING"` in the Config dataclass. This ensures:
- Normal operation only shows warnings and errors
- Clean, readable output for analysis results
- INFO logs are still available via `-v` flag
- DEBUG logs available via `-vv` flag

## Testing
- Verified the change is a simple one-line modification to the default value
- The logging infrastructure already supports dynamic log levels via CLI flags
- No changes to existing logging calls were necessary

## Impact
This is a backward-compatible change that improves user experience. Users who rely on INFO logs can simply add the `-v` flag to their commands.

Fixes #33